### PR TITLE
fix to use __send__ for overwrite protection

### DIFF
--- a/lib/msgpack/rpc_over_http/server/dispatcher.rb
+++ b/lib/msgpack/rpc_over_http/server/dispatcher.rb
@@ -16,7 +16,7 @@ module MessagePack
             raise NoMethodError, "method `#{method}' is not accepted"
           end
 
-          return @handler.send(method, *params)
+          return @handler.__send__(method, *params)
         end
       end
     end


### PR DESCRIPTION
Patch for situations that @handler.send is overwritten.
