### PR TITLE
add gems for runtime into runtime_dependency correctly

### DIFF
--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -15,8 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MessagePack::RPCOverHTTP::VERSION
 
-  gem.add_development_dependency "rack", "~> 1.4.1"
-  gem.add_development_dependency "msgpack", "~> 0.4.7"
-  gem.add_development_dependency "celluloid", "~> 0.12.3"
-  gem.add_development_dependency "httpclient", "~> 2.3.0.1"
+  gem.add_runtime_dependency "rack", "~> 1.4.1"
+  gem.add_runtime_dependency "msgpack", "~> 0.4.7"
+  gem.add_runtime_dependency "celluloid", "~> 0.12.3"
+  gem.add_runtime_dependency "httpclient", "~> 2.3.0.1"
+
+  gem.add_development_dependency "thin"
 end


### PR DESCRIPTION
By 'add_development_dependency' in gemspec, we cannot install/load required gems with bundler.
