### PR TITLE
remove version dependencies for libraries

### DIFF
--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MessagePack::RPCOverHTTP::VERSION
 
-  gem.add_runtime_dependency "rack", "~> 1.4.1"
+  gem.add_runtime_dependency "rack"
   gem.add_runtime_dependency "msgpack", "~> 0.5.5"
   gem.add_runtime_dependency "celluloid", "~> 0.12.3"
-  gem.add_runtime_dependency "httpclient", "~> 2.3.0.1"
+  gem.add_runtime_dependency "httpclient"
 
   gem.add_development_dependency "thin"
 end


### PR DESCRIPTION
Libraries should not depends on any specified minor versions of external libraries.
So remove these major libraries version dependencies.

But `msgpack`'s version is very hard to change (sometimes broken).

With this change and `bundle update`, `test/run-test.rb` returns success on my pc.
