### PR TITLE
Update gems for jruby release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,14 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in msgpack-rpc-over-http.gemspec
 gemspec
 
-group :test do
-  gem 'test-unit', '~> 2.5.2'
-  gem 'thin'
+platforms :ruby do
+  group :test do
+    gem 'thin'
+  end
+end
+
+platforms :jruby do
+  group :test do
+    gem 'mizuno'
+  end
 end

--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "rack"
   gem.add_runtime_dependency "msgpack", "~> 0.5.5"
-  gem.add_runtime_dependency "celluloid", "~> 0.12.3"
+  gem.add_runtime_dependency "celluloid", "~> 0.16.0"
   gem.add_runtime_dependency "httpclient"
 
   gem.add_development_dependency "rake"

--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |gem|
   gem.version       = MessagePack::RPCOverHTTP::VERSION
 
   gem.add_runtime_dependency "rack"
-  gem.add_runtime_dependency "msgpack", "~> 0.5.5"
+  gem.add_runtime_dependency "msgpack", "~> 0.5.11"
   gem.add_runtime_dependency "celluloid", "~> 0.16.0"
   gem.add_runtime_dependency "httpclient"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "test-unit"
+  gem.add_development_dependency "test-unit", "~> 3.0"
 end

--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "celluloid", "~> 0.12.3"
   gem.add_runtime_dependency "httpclient"
 
-  gem.add_development_dependency "thin"
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,6 +31,13 @@ class MockHandler
   end
 end
 
+def jruby?
+  if /java/ =~ RUBY_PLATFORM
+    return true
+  end
+  false
+end
+
 def sleep_until_http_server_is_started(host, port)
   timeout(30) do 
     while stopped_test_app_server?(host, port)

--- a/test/mock_server.ru
+++ b/test/mock_server.ru
@@ -1,4 +1,7 @@
 #\ -s thin
+
+### NOTE: this file is not used with jruby. FIX test/test_client.rb #setup if this file is fixed.
+
 $LOAD_PATH.unshift(File.expand_path("./../lib", File.dirname(__FILE__)))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -1,3 +1,5 @@
+require 'rack'
+
 module MessagePack::RPCOverHTTP
   class TestClient < Test::Unit::TestCase
     def self.unused_port
@@ -13,13 +15,32 @@ module MessagePack::RPCOverHTTP
     def setup
       @client = Client.new("http://0.0.0.0:#{@@server_port}/")
       if @@is_stopped_test_app_server
-        pid = fork {
-          Rack::Server.start(config: "test/mock_server.ru", Port: @@server_port)
-          exit 0
-        }
-        at_exit do
-          Process.kill(:INT, pid)
-          Process.waitpid(pid)
+        if /java/ =~ RUBY_PLATFORM
+          mizuno = nil
+          thread = Thread.new do
+            Thread.current.abort_on_exception = true
+            require 'mizuno/server'
+            app = Rack::Builder.new {
+              # MockHandler is in helper.rb
+              run MessagePack::RPCOverHTTP::Server.app(MockHandler.new)
+            }
+            mizuno = Mizuno::Server.new
+            mizuno.run(app, embedded: true, threads: 1, port: @@server_port, host: '0.0.0.0')
+          end
+          at_exit do
+            mizuno.stop
+            thread.kill
+            thread.join
+          end
+        else
+          pid = fork {
+            Rack::Server.start(config: "test/mock_server.ru", Port: @@server_port)
+            exit 0
+          }
+          at_exit do
+            Process.kill(:INT, pid)
+            Process.waitpid(pid)
+          end
         end
         sleep_until_http_server_is_started("0.0.0.0", @@server_port)
         @@is_stopped_test_app_server = false
@@ -37,6 +58,8 @@ module MessagePack::RPCOverHTTP
     end
 
     def test_call_async
+      pend "msgpack-rpc-over-http does not support Client#async for jruby" if jruby?
+
       future = @client.call_async(:test, "a", "b")
       assert_equal ["a", "b"], future.value
       assert_raise(MessagePack::RPCOverHTTP::RuntimeError) do
@@ -62,6 +85,7 @@ module MessagePack::RPCOverHTTP
     end
 
     def test_stream
+      pend "msgpack-rpc-over-http does not support Client#stream for jruby" if jruby?
       expect = ["a", "b"]
       @client.stream(:stream_normal, "a", "b") do |res|
         assert_equal expect.shift, res
@@ -78,6 +102,7 @@ module MessagePack::RPCOverHTTP
     end
 
     def test_stream_async
+      pend "msgpack-rpc-over-http does not support Client#stream_async for jruby" if jruby?
       expect = ["a", "b"]
       future = @client.stream_async(:stream_normal, "a", "b") do |res|
         assert_equal expect.shift, res


### PR DESCRIPTION
Add jruby support w/ msgpack 0.5.11

    * msgpack-ruby 0.5.11 supports jruby
    * add another rack server `mizuno` for testing
      * `thin` doesn't support jruby
    * fix test server code
      * jruby doesn't support fork
      * fix to use threads instead of fork, and execute mizuno in it as embedded server
    * mark some tests as pending
      * stream/async features are not supported jruby platform yet

And some fixes of dependency problems.