### PR TITLE
Update msgpack dependency for recent versions

### DIFF
--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   end
 
   gem.add_runtime_dependency "rack"
-  gem.add_runtime_dependency "msgpack", "~> 0.5.11"
+  gem.add_runtime_dependency "msgpack", ">= 0.5.11"
   gem.add_runtime_dependency "celluloid", "~> 0.16.0"
   gem.add_runtime_dependency "httpclient"
 


### PR DESCRIPTION
Latest msgpack-ruby is now 1.0.0, and I believe that these versions works well with this library.