### PR TITLE
Support ext types

### DIFF
--- a/lib/msgpack/rpc_over_http/server.rb
+++ b/lib/msgpack/rpc_over_http/server.rb
@@ -11,11 +11,11 @@ module MessagePack
 
       # Retruns the application for MessagePack-RPC.
       # It's create with Rack::Builder
-      def self.app(handler)
+      def self.app(handler, factory = nil)
         return Rack::Builder.app do
           use Rack::Chunked
-          use RequestUnpacker
-          use ResponsePacker
+          use RequestUnpacker, factory
+          use ResponsePacker, factory
           use Dispatcher
           run handler
         end

--- a/lib/msgpack/rpc_over_http/server/request_unpacker.rb
+++ b/lib/msgpack/rpc_over_http/server/request_unpacker.rb
@@ -5,8 +5,9 @@ module MessagePack
       # Rack Middleware that unpacks a serialized string in a HTTP
       # request.
       class RequestUnpacker
-        def initialize(app)
+        def initialize(app, factory = nil)
           @app = app
+          @factory = factory || MessagePack::Factory.new
         end
 
         def call(env)
@@ -49,7 +50,8 @@ module MessagePack
         end
 
         def unpack(env, body)
-          msg = MessagePack.unpack(body)
+          unpacker = @factory.unpacker
+          msg = unpacker.feed(body).read
           env['msgpack-rpc.type'] = msg[0]
           case msg[0]
           when REQUEST

--- a/lib/msgpack/rpc_over_http/server/response_packer.rb
+++ b/lib/msgpack/rpc_over_http/server/response_packer.rb
@@ -5,8 +5,9 @@ module MessagePack
       # Rack Middleware that packs a result of a handler method and
       # create a HTTP Responce.
       class ResponsePacker
-        def initialize(dispatcher)
+        def initialize(dispatcher, factory = nil)
           @dispatcher = dispatcher
+          @factory = factory || MessagePack::Factory.new
         end
 
         def call(env)
@@ -20,20 +21,26 @@ module MessagePack
             res.body = body
             return [res.status.to_i, res.header, body]
           else
-            res.write self.class.pack(msgid, nil, body)
+            res.write pack(msgid, nil, body)
             return res.finish
           end
         rescue RPCOverHTTP::RemoteError => ex
-          res.write self.class.pack(msgid, ex.class.name, ex.message)
+          res.write pack(msgid, ex.class.name, ex.message)
           return res.finish
         rescue ::RuntimeError => ex
-          res.write(self.class.pack(
-              msgid, RPCOverHTTP::RuntimeError.name, ex.message))
+          res.write(pack(msgid, RPCOverHTTP::RuntimeError.name, ex.message))
           return res.finish
         end
 
-        def self.pack(msgid, error, result)
-          return MessagePack.pack([RESPONSE, msgid, error, result])
+        def pack(msgid, error, result)
+          packer = @factory.packer
+          packer.write([RESPONSE, msgid, error, result]).to_s
+        end
+
+        def self.pack(msgid, error, result, factory: nil)
+          factory ||= MessagePack::DefaultFactory
+          packer = factory.packer
+          packer.write([RESPONSE, msgid, error, result]).to_s
         end
       end
     end

--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   end
 
   gem.add_runtime_dependency "rack"
-  gem.add_runtime_dependency "msgpack", ">= 0.5.11"
+  gem.add_runtime_dependency "msgpack", "~> 1.0"
   gem.add_runtime_dependency "celluloid", "~> 0.16.0"
   gem.add_runtime_dependency "httpclient"
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -39,7 +39,7 @@ def jruby?
 end
 
 def sleep_until_http_server_is_started(host, port)
-  timeout(30) do 
+  timeout(30) do
     while stopped_test_app_server?(host, port)
       sleep 1
     end

--- a/test/mock_server.ru
+++ b/test/mock_server.ru
@@ -8,4 +8,16 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'msgpack-rpc-over-http'
 require 'helper'
 
-run MessagePack::RPCOverHTTP::Server.app(MockHandler.new)
+class Time
+  def self.from_msgpack_ext(data)
+    sec, usec = MessagePack.unpack(data)
+    Time.at(sec, usec)
+  end
+  def to_msgpack_ext
+    [to_i, usec].to_msgpack
+  end
+end
+msgpack_factory = MessagePack::Factory.new
+msgpack_factory.register_type(0x01, Time)
+
+run MessagePack::RPCOverHTTP::Server.app(MockHandler.new, msgpack_factory)


### PR DESCRIPTION
This change make it possible to pass/receive custom objects, which are serialized/deserialized via Extension types of MessagePack.
