### PR TITLE
Update celluloid dependency to support latest API for ext types

### DIFF
--- a/msgpack-rpc-over-http.gemspec
+++ b/msgpack-rpc-over-http.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "rack"
   gem.add_runtime_dependency "msgpack", "~> 1.0"
-  gem.add_runtime_dependency "celluloid", "~> 0.16.0"
+  gem.add_runtime_dependency "celluloid", "~> 0.17"
   gem.add_runtime_dependency "httpclient"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
When using [fluent-plugin-norikra](https://github.com/norikra/fluent-plugin-norikra) which uses msgpack-rpc-over-http internally with the latest [td-agent-3.8.0](https://github.com/treasure-data/omnibus-td-agent/tree/v3.8.0) ([fluentd-1.11.1](https://github.com/fluent/fluentd/tree/v1.11.1)), there is a conflict in [celluloid](https://rubygems.org/gems/celluloid)->[timers](https://rubygems.org/gems/timers).
I want to update the celluloid version.

This PR passed test.

Thank you.

### stack trace
```
/opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:2294:in `raise_if_conflicts': Unable to activate celluloid-0.16.0, because timers-4.3.0 conflicts with timers (~> 4.0.0) (Gem::ConflictError)
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1414:in `activate'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1448:in `block in activate_dependencies'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1434:in `each'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1434:in `activate_dependencies'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1416:in `activate'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1448:in `block in activate_dependencies'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1434:in `each'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1434:in `activate_dependencies'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/specification.rb:1416:in `activate'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems.rb:220:in `rescue in try_activate'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems.rb:213:in `try_activate'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:126:in `rescue in require'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:39:in `require'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-norikra-0.4.3/lib/fluent/plugin/out_norikra.rb:4:in `<top (required)>'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/registry.rb:102:in `block in search'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/registry.rb:99:in `each'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/registry.rb:99:in `search'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/registry.rb:44:in `lookup'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/plugin.rb:155:in `new_impl'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/plugin.rb:109:in `new_output'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/agent.rb:130:in `add_match'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/agent.rb:74:in `block in configure'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/agent.rb:64:in `each'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/agent.rb:64:in `configure'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/root_agent.rb:146:in `configure'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/engine.rb:105:in `configure'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/engine.rb:80:in `run_configure'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/supervisor.rb:551:in `run_supervisor'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/lib/fluent/command/fluentd.rb:341:in `<top (required)>'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.11.1/bin/fluentd:8:in `<top (required)>'
        from /opt/td-agent/embedded/bin/fluentd:23:in `load'
        from /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
        from /usr/sbin/td-agent:7:in `load'
        from /usr/sbin/td-agent:7:in `<main>'
```

### dependency

#### now
```
- fluentd-1.11.1
  - async-http-0.50.8 >= 0
    - async-1.24.2 ~> 1.23
      - timers-4.3.0 ~> 4.1

- fluent-plugin-norikra
  - norikra-client-1.5.0 >= 1.4.0
    - msgpack-rpc-over-http-0.1.0 ~> 0.1.0
      - celluloid-0.16.0 ~> 0.16.0
        - timers ~> 4.0.0
```

#### ideal
```
- fluent-plugin-norikra
  - norikra-client-1.5.1 >= 1.4.0
    - msgpack-rpc-over-http-0.1.1 ~> 0.1
      - celluloid-0.17.4(latest) ~> 0.17 or ~> 0.16    ← this PR
        - timers >= 4.1.1
```
